### PR TITLE
guard against really small time deltas when calculating throughput

### DIFF
--- a/Restor/Controllers/ViewControllers/DownloadImageViewController.m
+++ b/Restor/Controllers/ViewControllers/DownloadImageViewController.m
@@ -181,7 +181,7 @@
   uint64_t currBytes = self.progress.completedUnitCount;
   NSTimeInterval dt = currTime - self.startTime;
   NSString *throughput = @"";
-  if (dt > 0) {
+  if (dt > 1e-6) {
     throughput = [NSString stringWithFormat:@"(%@/sec)",
         [bf stringFromByteCount:(currBytes - self.startBytes) / dt]];
   }


### PR DESCRIPTION
This should usually only be called when dt ~= 1 sec, so making sure that dt > 1 microsecond seems reasonable enough.  With this check, change in bytes has to be >= 1e13 before stringFromByteCount will return negative values.