### PR TITLE
Attempt running ASR multiple times on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ sudo defaults write /Library/Preferences/com.google.corp.restor.plist DiskFilter
     "(bsdName != 'disk3s2')"
 ```
 
+### ASRAttempts
+
+__Optional__
+
+Set how many times Restor should attempt to run ASR until it runs successfully.
+This may help with issues where the Volume is not unmountable by ASR due to some
+external process (ie spotlight) holding onto it.  Defaults to 1.
+
+`sudo defaults write /Library/Preferences/com.google.corp.restor.plist ASRAttempts -int 5`
+
 ## 10.13 and APFS Note
 
 In order to restore an APFS 10.13 DMG to a machine, the host machine running

--- a/restord/ImageSessionServer.m
+++ b/restord/ImageSessionServer.m
@@ -263,7 +263,7 @@ static NSString * const kASRAttempts = @"ASRAttempts";
   int retries = (int)[[[NSUserDefaults alloc] initWithSuiteName:kPreferenceDomain] integerForKey:kASRAttempts];
   if (retries <= 0) retries = 1;
   NSLog(@"Will attempt ASR up to %d times.", retries);
-  for(int i = 0; i < retries; i++) {
+  for (int i = 0; i < retries; ++i) {
     [self unmountDisk:self.diskRef withOptions:kDADiskUnmountOptionWhole];
 
     self.asr = [[NSTask alloc] init];
@@ -299,9 +299,7 @@ static NSString * const kASRAttempts = @"ASRAttempts";
 
     // Clear readability handler or the file handle is never released.
     outputFh.readabilityHandler = nil;
-    if (self.asr && self.asr.terminationStatus == 0) {
-      break;
-    }
+    if (self.asr && self.asr.terminationStatus == 0) break;
     NSLog(@"%@ ASR attempt %d exit code: %d", self, i + 1, self.asr.terminationStatus);
   }
   return self.asr ? self.asr.terminationStatus : -1;


### PR DESCRIPTION
Run ASR multiple times on failure.  The number of attempts is controlled by the ASRAttempts configuration setting in the com.google.corp.restor profile.